### PR TITLE
feat: Kubernetes展開設定の追加

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: iot-platform-config
+  namespace: iot-platform
+data:
+  RAILS_ENV: "development"
+  RAILS_LOG_TO_STDOUT: "true"
+  DATABASE_HOST: "postgres-service"
+  DATABASE_PORT: "5432"
+  DATABASE_USERNAME: "postgres"
+  REDIS_URL: "redis://redis-service:6379/0"
+  AWS_ENDPOINT: "http://localstack-service:4566"
+  AWS_REGION: "ap-northeast-1"
+  DYNAMODB_ENDPOINT: "http://localstack-service:4566"
+  DYNAMODB_REGION: "ap-northeast-1"
+  LOG_LEVEL: "debug"
+  CACHE_STORE: "redis"
+  SESSION_STORE: "redis"
+  DEVELOPMENT_MODE: "true"
+  DEBUG: "true"

--- a/k8s/deployments.yaml
+++ b/k8s/deployments.yaml
@@ -1,0 +1,222 @@
+# LocalStack Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: localstack
+  namespace: iot-platform
+  labels:
+    app: localstack
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: localstack
+  template:
+    metadata:
+      labels:
+        app: localstack
+    spec:
+      containers:
+      - name: localstack
+        image: localstack/localstack:3.0
+        ports:
+        - containerPort: 4566
+        env:
+        - name: DEBUG
+          value: "1"
+        - name: SERVICES
+          value: "dynamodb,s3,sns,sqs"
+        - name: AWS_ACCESS_KEY_ID
+          value: "test"
+        - name: AWS_SECRET_ACCESS_KEY
+          value: "test"
+        - name: AWS_DEFAULT_REGION
+          value: "ap-northeast-1"
+        - name: DYNAMODB_SHARE_DB
+          value: "1"
+        - name: PERSISTENCE
+          value: "1"
+        volumeMounts:
+        - name: localstack-data
+          mountPath: /var/lib/localstack
+      volumes:
+      - name: localstack-data
+        emptyDir: {}
+
+---
+# Redis Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: iot-platform
+  labels:
+    app: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - name: redis
+        image: redis:7-alpine
+        ports:
+        - containerPort: 6379
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+      volumes:
+      - name: redis-data
+        emptyDir: {}
+
+---
+# PostgreSQL Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: iot-platform
+  labels:
+    app: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:15-alpine
+        ports:
+        - containerPort: 5432
+        env:
+        - name: POSTGRES_DB
+          value: "iot_platform_development"
+        - name: POSTGRES_USER
+          valueFrom:
+            configMapKeyRef:
+              name: iot-platform-config
+              key: DATABASE_USERNAME
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: iot-platform-secret
+              key: DATABASE_PASSWORD
+        volumeMounts:
+        - name: postgres-data
+          mountPath: /var/lib/postgresql/data
+      volumes:
+      - name: postgres-data
+        emptyDir: {}
+
+---
+# Rails Application Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rails-app
+  namespace: iot-platform
+  labels:
+    app: rails-app
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: rails-app
+  template:
+    metadata:
+      labels:
+        app: rails-app
+    spec:
+      initContainers:
+      - name: db-migrate
+        image: iot-platform:latest
+        command: ["rails", "db:create", "db:migrate"]
+        envFrom:
+        - configMapRef:
+            name: iot-platform-config
+        - secretRef:
+            name: iot-platform-secret
+        env:
+        - name: DATABASE_URL
+          value: "postgresql://$(DATABASE_USERNAME):$(DATABASE_PASSWORD)@$(DATABASE_HOST):$(DATABASE_PORT)/iot_platform_development"
+      containers:
+      - name: rails
+        image: iot-platform:latest
+        ports:
+        - containerPort: 3000
+        envFrom:
+        - configMapRef:
+            name: iot-platform-config
+        - secretRef:
+            name: iot-platform-secret
+        env:
+        - name: DATABASE_URL
+          value: "postgresql://$(DATABASE_USERNAME):$(DATABASE_PASSWORD)@$(DATABASE_HOST):$(DATABASE_PORT)/iot_platform_development"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 3000
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 3000
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+
+---
+# Sidekiq Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sidekiq
+  namespace: iot-platform
+  labels:
+    app: sidekiq
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sidekiq
+  template:
+    metadata:
+      labels:
+        app: sidekiq
+    spec:
+      containers:
+      - name: sidekiq
+        image: iot-platform:latest
+        command: ["bundle", "exec", "sidekiq"]
+        envFrom:
+        - configMapRef:
+            name: iot-platform-config
+        - secretRef:
+            name: iot-platform-secret
+        env:
+        - name: DATABASE_URL
+          value: "postgresql://$(DATABASE_USERNAME):$(DATABASE_PASSWORD)@$(DATABASE_HOST):$(DATABASE_PORT)/iot_platform_development"
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "200m"

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: iot-platform
+  labels:
+    name: iot-platform
+    environment: development
+    purpose: iot-data-collection

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: iot-platform-secret
+  namespace: iot-platform
+type: Opaque
+data:
+  # Base64エンコードされた値
+  # echo -n "postgres" | base64
+  DATABASE_PASSWORD: cG9zdGdyZXM=
+  # echo -n "test" | base64
+  AWS_ACCESS_KEY_ID: dGVzdA==
+  # echo -n "test" | base64
+  AWS_SECRET_ACCESS_KEY: dGVzdA==
+  # echo -n "your_secret_key_base_here" | base64
+  SECRET_KEY_BASE: eW91cl9zZWNyZXRfa2V5X2Jhc2VfaGVyZQ==
+  # echo -n "your_master_key_here" | base64
+  RAILS_MASTER_KEY: eW91cl9tYXN0ZXJfa2V5X2hlcmU=

--- a/k8s/services.yaml
+++ b/k8s/services.yaml
@@ -1,0 +1,94 @@
+# LocalStack Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: localstack-service
+  namespace: iot-platform
+  labels:
+    app: localstack
+spec:
+  selector:
+    app: localstack
+  ports:
+  - name: http
+    port: 4566
+    targetPort: 4566
+    protocol: TCP
+  type: ClusterIP
+
+---
+# Redis Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-service
+  namespace: iot-platform
+  labels:
+    app: redis
+spec:
+  selector:
+    app: redis
+  ports:
+  - name: redis
+    port: 6379
+    targetPort: 6379
+    protocol: TCP
+  type: ClusterIP
+
+---
+# PostgreSQL Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-service
+  namespace: iot-platform
+  labels:
+    app: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+  - name: postgres
+    port: 5432
+    targetPort: 5432
+    protocol: TCP
+  type: ClusterIP
+
+---
+# Rails Application Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: rails-app-service
+  namespace: iot-platform
+  labels:
+    app: rails-app
+spec:
+  selector:
+    app: rails-app
+  ports:
+  - name: http
+    port: 3000
+    targetPort: 3000
+    protocol: TCP
+  type: LoadBalancer
+
+---
+# Rails Application NodePort Service (for local development)
+apiVersion: v1
+kind: Service
+metadata:
+  name: rails-app-nodeport
+  namespace: iot-platform
+  labels:
+    app: rails-app
+spec:
+  selector:
+    app: rails-app
+  ports:
+  - name: http
+    port: 3000
+    targetPort: 3000
+    nodePort: 30000
+    protocol: TCP
+  type: NodePort


### PR DESCRIPTION
## 📋 PRの概要

IoTプラットフォームをKubernetesでマイクロサービスとして展開するための設定を追加します。

## ☸️ 変更内容

### k8s/namespace.yaml
- iot-platform名前空間の定義
- リソースの論理的分離

### k8s/configmap.yaml  
- 環境変数の一元管理
- アプリケーション設定の外部化

### k8s/secret.yaml
- 機密情報の安全な管理
- データベース・AWS認証情報

### k8s/deployments.yaml
- LocalStack、Redis、PostgreSQL、Rails、Sidekiqの展開設定

### k8s/services.yaml
- サービス公開・通信設定

## 🔧 展開手順

```bash
kubectl apply -f k8s/
kubectl get pods -n iot-platform
```

## 📈 影響範囲

- 新規ファイル追加のみ
- Kubernetes学習環境の構築