### PR TITLE
fix: Redisヘルスチェックの実装を修正

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -232,7 +232,8 @@ class DashboardController < ApplicationController
 
   def check_redis_health
     begin
-      Rails.cache.redis.ping
+      redis_client = Redis.new(url: ENV.fetch('REDIS_URL', 'redis://localhost:6379/0'))
+      redis_client.ping
       { status: 'healthy', message: 'Connected' }
     rescue => e
       { status: 'error', message: e.message }


### PR DESCRIPTION
- Redisクライアントの初期化方法を修正し、環境変数からREDIS_URLを取得するように変更
- pingメソッドをRedisクライアントに対して呼び出すように修正