### PR TITLE
feat: importブロックの検証

### DIFF
--- a/terraform/dynamodb_imports.tf
+++ b/terraform/dynamodb_imports.tf
@@ -1,0 +1,43 @@
+# DynamoDBインポート用設定
+
+resource "aws_dynamodb_table" "test_import_table" {
+  billing_mode                = "PAY_PER_REQUEST"
+  deletion_protection_enabled = false
+  hash_key                    = "id"
+  name                        = "test-import-table"
+  range_key                   = null
+  read_capacity               = 0
+  restore_date_time           = null
+  restore_source_name         = null
+  restore_source_table_arn    = null
+  restore_to_latest_time      = null
+  stream_enabled              = false
+  stream_view_type            = null
+  table_class                 = "STANDARD"
+  tags = {
+    Environment = "development"
+    Name        = "Test Import Table"
+    Purpose     = "import_test"
+  }
+  tags_all = {
+    Environment = "development"
+    Name        = "Test Import Table"
+    Purpose     = "import_test"
+  }
+  write_capacity = 0
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = false
+    # recovery_period_in_days = 0 # この行を削除してエラーを修正
+  }
+
+  ttl {
+    attribute_name = null
+    enabled        = false
+  }
+}

--- a/terraform/import_test.tf
+++ b/terraform/import_test.tf
@@ -1,0 +1,14 @@
+# インポートテスト用のimportブロック
+# ※ インポート完了済みのため、コメントアウト
+
+# 手動作成したDynamoDBテーブルをインポート（完了済み）
+# import {
+#   to = aws_dynamodb_table.test_import_table
+#   id = "test-import-table"
+# }
+
+# 手動作成したS3バケットをインポート（完了済み）
+# import {
+#   to = aws_s3_bucket.test_import_bucket
+#   id = "test-import-bucket"
+# }

--- a/terraform/s3_imports.tf
+++ b/terraform/s3_imports.tf
@@ -1,0 +1,18 @@
+# S3インポート用設定
+
+resource "aws_s3_bucket" "test_import_bucket" {
+  bucket              = "test-import-bucket"
+  bucket_prefix       = null
+  force_destroy       = null
+  object_lock_enabled = false
+  tags = {
+    Environment = "development"
+    Name        = "Test Import Bucket"
+    Purpose     = "import_test"
+  }
+  tags_all = {
+    Environment = "development"
+    Name        = "Test Import Bucket"
+    Purpose     = "import_test"
+  }
+}


### PR DESCRIPTION
## 作業概要
LocalStack環境でTerraformのimportブロック機能を完全検証し、
既存リソースからHCL設定の自動生成とモジュール分割を実施。

## 実施した手順
1. LocalStack上にテスト用リソースを手動作成
   - DynamoDBテーブル: test-import-table
   - S3バケット: test-import-bucket

2. importブロックを作成 (terraform/import_test.tf)
   - DynamoDBとS3リソースのインポート定義

3. terraform plan -generate-config-out で設定自動生成
   - 既存リソースからHCLコードを自動生成
   - point_in_time_recovery設定のエラーを修正

4. 生成された設定をモジュール別に分割
   - terraform/dynamodb_imports.tf: DynamoDB専用設定
   - terraform/s3_imports.tf: S3専用設定

5. terraform applyでインポート実行
   - 2つのリソースを正常にTerraformステートに取り込み

6. importブロックをコメントアウト
   - インポート完了後の適切な管理のため

## 技術的学習ポイント
- -generate-config-outオプションによる自動HCL生成
- LocalStackでのS3 path-style設定 (s3_use_path_style = true)
- DynamoDB point_in_time_recovery設定の注意点
- インポート後のimportブロック管理ベストプラクティス

## ファイル構成
- terraform/import_test.tf: インポートブロック（コメントアウト済み）
- terraform/dynamodb_imports.tf: DynamoDBテーブル設定
- terraform/s3_imports.tf: S3バケット設定